### PR TITLE
Remove redundant(?) Build-Depends

### DIFF
--- a/memoize.cabal
+++ b/memoize.cabal
@@ -23,8 +23,7 @@ description:
         Haskell, appear to be true.
 
 library
-  build-depends:        haskell98 >=1 && <2,
-                        base >=3 && <5,
+  build-depends:        base >=3 && <5,
                         template-haskell >=2
 
   ghc-options:          -Wall -fno-warn-orphans


### PR DESCRIPTION
Prelude is exported by both haskell98 and base, causing ambiguous references on 7.4.1.
