### PR TITLE
Supporting template-haskell 2.8.0.0.

### DIFF
--- a/Data/Function/Memoize/TH.hs
+++ b/Data/Function/Memoize/TH.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE
       TemplateHaskell,
-      UnicodeSyntax
+      UnicodeSyntax,
+      CPP
     #-}
 {- |
     Exports functions for deriving instances of 'Memoizable' using
@@ -165,7 +166,11 @@ buildContext mindices tvbs tvs =
     Nothing  → filterBy isStar       tvbs   tvs
   --
   isStar (PlainTV _) = True
+#if __GLASGOW_HASKELL__ >= 706
+  isStar (KindedTV _ StarT) = True
+#else
   isStar (KindedTV _ StarK) = True
+#endif
   isStar (KindedTV _ _) = False
   --
   filterBy ∷ (a → Bool) → [a] → [b] → [b]


### PR DESCRIPTION
This patch supports GHC 7.6.3 in Haskell Platform 2013.2.0.0.
Please merge this and release a new version.
