### PR TITLE
Fix what ghc-7.10 calls an "illegal variable name"

### DIFF
--- a/Data/Function/Memoize/TH.hs
+++ b/Data/Function/Memoize/TH.hs
@@ -212,7 +212,7 @@ buildMethodExp ∷ [(Name, Int)] → ExpQ
 buildMethodExp cons = do
   f      ← newName "f"
   look   ← newName "look"
-  caches ← mapM (newName . ("cache"++) . nameBase . fst) cons
+  caches ← mapM (\ _ -> newName "cache") cons
   lam1E (varP f)
     (letE
       (buildLookup look cons caches


### PR DESCRIPTION
I've built cabal-debian with this change and used it extensively.