### PR TITLE
Add Generics

### DIFF
--- a/memoize.cabal
+++ b/memoize.cabal
@@ -51,12 +51,27 @@ test-suite memoize-test2
     main-is: test2.hs
     build-depends: base, memoize
 
+test-suite memoize-test2g
+    default-language: Haskell98
+    hs-source-dirs: test
+    type: exitcode-stdio-1.0
+    main-is: test2g.hs
+    build-depends: base, memoize
+
 test-suite memoize-test3
     default-language: Haskell98
     hs-source-dirs: test
     other-modules: Test3Helper
     type: exitcode-stdio-1.0
     main-is: test3.hs
+    build-depends: base, memoize
+
+test-suite memoize-test3g
+    default-language: Haskell98
+    hs-source-dirs: test
+    other-modules: Test3Helper
+    type: exitcode-stdio-1.0
+    main-is: test3g.hs
     build-depends: base, memoize
 
 source-repository head

--- a/src/Data/Function/Memoize/Class.hs
+++ b/src/Data/Function/Memoize/Class.hs
@@ -1,4 +1,9 @@
-{-# LANGUAGE
+{-# LANGUAGE 
+      DefaultSignatures,
+      EmptyCase,
+      FlexibleContexts,
+      LambdaCase,
+      TypeOperators,
       UnicodeSyntax
     #-}
 {- |
@@ -8,8 +13,42 @@ module Data.Function.Memoize.Class (
   Memoizable(..)
 ) where
 
+import GHC.Generics
+
 -- | A memoization class.  An instance @'Memoizable' T@ for some
 --   type @T@ means that that 'memoize' method can memoize for
 --   parameters of type @T@.
 class Memoizable a where
   memoize ∷ (a → v) → a → v
+  default memoize :: (Generic a, GMemoizable (Rep a)) => (a → v) → a → v
+  memoize f = gMemoize (f . to) . from
+
+class GMemoizable a where
+  gMemoize :: (a p → v) → a p → v
+
+instance GMemoizable f => GMemoizable (M1 i c f) where
+  gMemoize f = gMemoize (f . M1) . unM1
+
+instance GMemoizable V1 where
+  gMemoize _f = \case
+
+instance GMemoizable U1 where
+  gMemoize f =
+    let fu = f U1
+     in \U1 → fu
+
+instance Memoizable c => GMemoizable (K1 i c) where
+  gMemoize f = memoize (f . K1) . unK1
+
+instance (GMemoizable a, GMemoizable b) => GMemoizable (a :*: b) where
+  gMemoize f =
+    let f' = gMemoize (\x → gMemoize (\y → f (x :*: y)))
+     in \(x :*: y) → f' x y
+
+instance (GMemoizable a, GMemoizable b) => GMemoizable (a :+: b) where
+  gMemoize f =
+    let fL = gMemoize (f . L1)
+        fR = gMemoize (f . R1)
+     in \case
+          L1 x → fL x
+          R1 x → fR x

--- a/test/test2g.hs
+++ b/test/test2g.hs
@@ -1,0 +1,16 @@
+{-# language DeriveAnyClass, DeriveGeneric #-}
+
+import Data.Function.Memoize
+import GHC.Generics (Generic)
+
+data List a = Nil | Cons a (List a)
+  deriving (Generic, Memoizable)
+
+main = print $
+  let lcs = memoFix2 -- exponential time if you put   fix   here
+          $ \ f -> \ a b -> case (a,b) of
+            (Cons x a', Cons y b') ->
+               maximum [ if x == y then 1 + f a' b'  else 0, f a b', f a' b ]
+            _ -> 0
+      a = iterate (Cons ()) Nil !! 20
+  in  lcs a a

--- a/test/test3g.hs
+++ b/test/test3g.hs
@@ -1,0 +1,37 @@
+{-# language DeriveGeneric, GADTs, StandaloneDeriving #-}
+
+import Data.Function.Memoize
+import Control.Monad (forM_, when)
+import Test3Helper
+import GHC.Generics (Generic)
+
+-- NonstandardParams is defined by:
+--
+--   data NonstandardParams a b
+--     = NonstandardParams (a -> Bool) b
+--
+-- This won’t compile because it needs addition typeclass constraints in
+-- the instance context:
+--
+--   $(deriveMemoizable ''NonstandardParams)
+
+deriving instance Generic (NonstandardParams a b)
+instance (Eq a, Enum a, Bounded a, Memoizable b) => Memoizable (NonstandardParams a b)
+
+applyToLength :: NonstandardParams Bool Int -> Bool
+applyToLength (NonstandardParams f z) = f (odd z)
+
+cases = [ (NonstandardParams id 5, True)
+        , (NonstandardParams id 6, False)
+        , (NonstandardParams not 5, False)
+        , (NonstandardParams not 6, True)
+        ]
+
+main :: IO ()
+main = do
+  let memoized = memoize applyToLength
+  forM_ cases $ \(input, expected) -> do
+    let actual = applyToLength input
+    when (actual /= expected) $
+      fail $ "Test failed: got " ++ show actual ++
+             " when " ++ show expected ++ " expected."


### PR DESCRIPTION
Allow deriving instances of Memoize via `DeriveGeneric` and `DeriveAnyClass` rather than via TemplateHaskell.