### PR TITLE
Add lower bound for base

### DIFF
--- a/memoize.cabal
+++ b/memoize.cabal
@@ -25,7 +25,7 @@ description:
 extra-source-files: README.md CHANGELOG.md
 
 library
-  build-depends:        base >=3 && <5,
+  build-depends:        base >=4.8 && <5,
                         template-haskell >=2 && <3
   default-language:     Haskell98
 


### PR DESCRIPTION
Data.Void is not available before `base-4.8`.
https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-Void.html

As a Hackage trustee, I made following revisions to prohibit unbuildable configurations:
https://hackage.haskell.org/package/memoize-1.1.1/revisions/
https://hackage.haskell.org/package/memoize-1.1.0/revisions/