### PR TITLE
Fix slowness issue with large integers

### DIFF
--- a/src/Data/Function/Memoize.hs
+++ b/src/Data/Function/Memoize.hs
@@ -46,7 +46,7 @@ import Debug.Trace
 import Data.Function.Memoize.Class
 import Data.Function.Memoize.TH
 
-import           Data.Bits      (shiftL, shiftR, finiteBitSize, (.&.))
+import           Data.Bits      (shiftL, shiftR, finiteBitSize, (.&.), (.|.))
 import qualified Data.Complex   as Complex
 import qualified Data.Ratio     as Ratio
 #ifdef COMPAT_HAS_SOLO
@@ -264,7 +264,7 @@ encodeInteger i = fromInteger (i .&. maxInt) : encodeInteger (i `shiftR` intBits
 
 decodeInteger :: [Int] -> Integer
 decodeInteger  = foldr op 0 where
-  op i i' = fromIntegral i + i' `shiftL` intBits
+  op i i' = fromIntegral i .|. i' `shiftL` intBits
 
 intBits :: Int
 intBits  = finiteBitSize (0 :: Int) - 1

--- a/src/Data/Function/Memoize.hs
+++ b/src/Data/Function/Memoize.hs
@@ -147,7 +147,7 @@ traceMemoize f = memoize (\a → traceShow a (f a))
 --- Binary-tree based memo caches
 ---
 
--- Used for both 'Integer' and arbitrary 'Int'-like types.
+-- Used for arbitrary types that are bounded and enumerable:
 
 data BinaryTreeCache v
  = BinaryTreeCache {
@@ -155,30 +155,6 @@ data BinaryTreeCache v
     btLeft, btRight ∷ BinaryTreeCache v
    }
    deriving Functor
-
----
---- 'Integer' memoization
----
-
-instance Memoizable Integer where
-  memoize f = memoize (f . decodeInteger) . encodeInteger
-
-encodeInteger :: Integer -> [Int]
-encodeInteger 0 = []
-encodeInteger i | minInt <= i && i <= maxInt
-                = [fromInteger i]
-encodeInteger i = fromInteger (i .&. maxInt) : encodeInteger (i `shiftR` intBits)
-
-decodeInteger :: [Int] -> Integer
-decodeInteger  = foldr op 0 where
-  op i i' = fromIntegral i + i' `shiftL` intBits
-
-intBits :: Int
-intBits  = finiteBitSize (0 :: Int) - 1
-
-minInt, maxInt :: Integer
-minInt = fromIntegral (minBound :: Int)
-maxInt = fromIntegral (maxBound :: Int)
 
 ---
 --- Enumerable types using binary search trees
@@ -272,6 +248,30 @@ deriveMemoizable ''(,,,,,,,,)
 deriveMemoizable ''(,,,,,,,,,)
 deriveMemoizable ''(,,,,,,,,,,)
 deriveMemoizable ''(,,,,,,,,,,,)
+
+---
+--- 'Integer' memoization
+---
+
+instance Memoizable Integer where
+  memoize f = memoize (f . decodeInteger) . encodeInteger
+
+encodeInteger :: Integer -> [Int]
+encodeInteger 0 = []
+encodeInteger i | minInt <= i && i <= maxInt
+                = [fromInteger i]
+encodeInteger i = fromInteger (i .&. maxInt) : encodeInteger (i `shiftR` intBits)
+
+decodeInteger :: [Int] -> Integer
+decodeInteger  = foldr op 0 where
+  op i i' = fromIntegral i + i' `shiftL` intBits
+
+intBits :: Int
+intBits  = finiteBitSize (0 :: Int) - 1
+
+minInt, maxInt :: Integer
+minInt = fromIntegral (minBound :: Int)
+maxInt = fromIntegral (maxBound :: Int)
 
 ---
 --- Functions

--- a/src/Data/Function/Memoize.hs
+++ b/src/Data/Function/Memoize.hs
@@ -158,9 +158,21 @@ data BinaryTreeCache v
 ---
 --- 'Integer' memoization
 ---
+signedBitSize = (finiteBitSize (0 :: Int) - 1) :: Int
+maxInt = fromIntegral (maxBound :: Int) :: Integer
+
+toIntBase :: Integer -> [Int]
+toIntBase 0 = []
+toIntBase i | i <= maxInt && i >= fromIntegral (minBound :: Int) =
+   [fromInteger i]
+toIntBase i = fromInteger (i .&. maxInt) : toIntBase (i `shiftR` signedBitSize)
+
+fromIntBase :: [Int] -> Integer
+fromIntBase [] = 0
+fromIntBase (x:xs) = fromIntBase xs `shiftL` signedBitSize + fromIntegral x
 
 instance Memoizable Integer where
-  memoize f = integerLookup (f <$> theIntegers)
+   memoize f = memoize (f . fromIntBase) . toIntBase
 
 -- | An integer cache stores a value for 0 and separate caches for the
 --   positive and negative integers.


### PR DESCRIPTION
example of issue before fix:

import Data.Function.Memoize
f :: (Integer, Integer) -> Integer
f = memoFix (\f (b,a)->if a>0 then f (b,a-1) else b) main=print $ f (10^10000, 10)